### PR TITLE
Adds `no_std` support for `ErrContext`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "3"
 members = ["error_set", "error_set_impl", "error_set/test_no_std", "err_trail"]

--- a/err_trail/Cargo.toml
+++ b/err_trail/Cargo.toml
@@ -2,14 +2,14 @@
 name = "err_trail"
 description = "Add context to errors through logging"
 version = "0.8.5"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 documentation = "https://docs.rs/err_trail"
 repository = "https://github.com/mcmah309/error_set"
 
 [dependencies]
-tracing = { version = "0.1", optional = true }
-log = { version = "0.4", optional = true }
+tracing = { version = "0.1", default-features = false, optional = true }
+log = { version = "0.4", default-features = false, optional = true }
 defmt = { version = "0.3", optional = true }
 
 [dev-dependencies]
@@ -18,12 +18,6 @@ lazy_static = "1"
 
 [features]
 default = ["stub"]
-# Enables support for the tracing crate. Adds methods to `Result` that are applied on `Err` - e.g. `result.warn(...)`.
-tracing = ["dep:tracing"]
-# Enables support for the log crate. Adds methods to `Result` that are applied on `Err` - e.g. `result.warn(...)`.
-log = ["dep:log"]
-# Enables support for the defmt crate, which works with no_std. Adds methods to `Result` that are applied on `Err` - e.g. `result.warn(...)`.
-defmt = ["dep:defmt"]
 # Enables support for the log/tracing/defmt api, without pulling in any crates. Allowing a downstream to choose the appropriate crate.
 stub = []
 

--- a/err_trail/src/lib.rs
+++ b/err_trail/src/lib.rs
@@ -1,9 +1,9 @@
-#![cfg_attr(not(any(test, feature = "tracing", feature = "log")), no_std)]
+#![cfg_attr(not(test), no_std)]
 
 #[cfg(any(feature = "tracing", feature = "log", feature = "stub"))]
 mod tracing_log_stub;
 #[cfg(any(feature = "tracing", feature = "log", feature = "stub"))]
-pub use  tracing_log_stub::*;
+pub use tracing_log_stub::*;
 
 #[cfg(feature = "defmt")]
 mod defmt;

--- a/error_set/Cargo.toml
+++ b/error_set/Cargo.toml
@@ -15,9 +15,9 @@ error_set_impl = { version = "=0.8.5", path = "../error_set_impl" }
 err_trail = {version = "=0.8.5", path = "../err_trail", default-features = false, optional = true }
 
 # features
-tracing = { version = "0.1", optional = true }
-log = { version = "0.4", optional = true }
-defmt = { version = "0.3", optional = true }
+tracing = { version = "0.1", optional = true, default-features = false }
+log = { version = "0.4", optional = true, default-features = false }
+defmt = { version = "0.3", optional = true, default-features = false }
 
 [dev-dependencies]
 trybuild = "^1.0.91"

--- a/error_set/src/lib.rs
+++ b/error_set/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(any(test, feature = "tracing", feature = "log")), no_std)]
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
This adds support for `no_std` while retaining support for tracing or log.