### PR TITLE
Fix expansion of unit error structs by including semicolon token from input

### DIFF
--- a/error_set_impl/src/expand.rs
+++ b/error_set_impl/src/expand.rs
@@ -79,7 +79,7 @@ fn add_struct_error(error_struct: AstErrorStruct, token_stream: &mut TokenStream
     token_stream.append_all(quote! {
         #(#attrs)*
         #debug
-        #vis #struct_token #struct_name #impl_generics #where_generics #fields
+        #vis #struct_token #struct_name #impl_generics #where_generics #fields #semi_token
     });
 
     let mut has_source_field = false;


### PR DESCRIPTION
Hi,
Thanks for adding error structs! That allowed me to remove a macro I created just for that use case :-)

But they don't work with unit structs, because the semicolon isn't passed through to the output.

Here is a patch to fix that.

Fixes:

```rust
error_set! {
    #[display("operation not permitted (path is reserved for system use)")]
    struct ReservedPath;
}
```