### PR TITLE
Accept Docstring for Struct Fields

### DIFF
--- a/error_set/tests/mod.rs
+++ b/error_set/tests/mod.rs
@@ -494,6 +494,7 @@ pub mod error_struct_and_enums {
     #[test]
     fn test() {
         let x: AuthError = AuthError::UserDoesNotExist1 {
+            /// This is a doc comment
             name: "john".to_string(),
             role: 30,
         };

--- a/error_set_impl/src/ast.rs
+++ b/error_set_impl/src/ast.rs
@@ -649,18 +649,30 @@ fn extract_cfg(attributes: Vec<Attribute>) -> (Vec<Attribute>, Vec<Attribute>) {
     (attributes, cfgs)
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub(crate) struct AstInlineErrorVariantField {
+    pub(crate) attributes: Vec<Attribute>,
     pub(crate) name: Ident,
     pub(crate) r#type: syn::Type,
 }
 
 impl Parse for AstInlineErrorVariantField {
     fn parse(input: ParseStream) -> Result<Self> {
+        let attributes = input.call(Attribute::parse_outer)?;
         let name: Ident = input.parse()?;
         let _: syn::Token![:] = input.parse()?;
         let r#type: syn::Type = input.parse()?;
-        Ok(AstInlineErrorVariantField { name, r#type })
+        Ok(AstInlineErrorVariantField {
+            attributes,
+            name,
+            r#type,
+        })
+    }
+}
+
+impl PartialEq for AstInlineErrorVariantField {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.r#type == other.r#type
     }
 }
 

--- a/error_set_impl/src/expand.rs
+++ b/error_set_impl/src/expand.rs
@@ -201,13 +201,14 @@ fn add_enum(error_enum_node: &ErrorEnumGraphNode, token_stream: &mut TokenStream
                 let cfg_attributes = &r#struct.cfg_attributes;
                 let name = &r#struct.name;
                 let fields = &r#struct.fields;
+                let field_attributes = fields.iter().map(|e| &e.attributes);
                 let field_names = fields.iter().map(|e| &e.name);
                 let field_types = fields.iter().map(|e| &e.r#type);
                 error_variant_tokens.append_all(quote::quote! {
                     #(#cfg_attributes)*
                     #(#attributes)*
                     #name {
-                        #(#field_names : #field_types),*
+                        #(#(#field_attributes)* #field_names : #field_types),*
                     },
                 });
             }
@@ -216,6 +217,7 @@ fn add_enum(error_enum_node: &ErrorEnumGraphNode, token_stream: &mut TokenStream
                 let cfg_attributes = &source_struct.cfg_attributes;
                 let name = &source_struct.name;
                 let fields = &source_struct.fields;
+                let field_attributes = fields.iter().map(|e| &e.attributes);
                 let field_names = fields.iter().map(|e| &e.name);
                 let field_types = fields.iter().map(|e| &e.r#type);
                 let source_type = &source_struct.source_type;
@@ -224,7 +226,7 @@ fn add_enum(error_enum_node: &ErrorEnumGraphNode, token_stream: &mut TokenStream
                     #(#attributes)*
                     #name {
                         source: #source_type,
-                        #(#field_names : #field_types),*
+                        #(#(#field_attributes)* #field_names : #field_types),*
                     },
                 });
             }

--- a/error_set_impl/src/resolve.rs
+++ b/error_set_impl/src/resolve.rs
@@ -371,6 +371,7 @@ fn replace_generics_in_fields(
     if old_to_new.contains_key(&field.r#type) {
         let new_type = old_to_new.get(&field.r#type).unwrap().clone();
         return AstInlineErrorVariantField {
+            attributes: field.attributes.clone(),
             name: field.name.clone(),
             r#type: new_type.clone(),
         };
@@ -384,6 +385,7 @@ fn replace_generics_in_fields(
             let new_type = syn::parse_str::<syn::Type>(&replaced)
                 .expect("Failed to parse replaced type back into type");
             return AstInlineErrorVariantField {
+                attributes: field.attributes.clone(),
                 name: field.name.clone(),
                 r#type: new_type.clone(),
             };


### PR DESCRIPTION
## Motivation
I really missed the feature to add docstrings to fields, especially when using `#![warn(missing_docs)]` or something alike.

## Context
Full disclaimer: the generated changes are llm assisted, but the changes are small enough so that I think they are reviewable.

## How to test
cargo new x

```rs
use error_set::error_set;

error_set! {
    Foo := {
        Bar {
            /// This is a docstring
            foo: u8,
        }
    }
}
```

And compare both verions of error_set:
```toml
[dependencies]
# comment one!
error_set = "0.9.1"
error_set = { git = "https://github.com/julianbuettner/error_set.git", rev = "12dda7ed37108d74456d89f88667c08b936c54fd" }
```

Then run `cargo doc` and open the docs